### PR TITLE
fix scalingo cron memory crash

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -34,6 +34,27 @@
         echo "[CRON] " . $line;
       }
     }
+
+    // this is a infinite loop, memory from used variables should be tag for cleanup
+    // (otherwise your app will crash without memory)
+    unset( $cron );
+    unset( $report );
+    if( isset( $job_report ) ) {
+      unset( $job_report );
+    }
+    if( isset( $output ) ) {
+      unset( $output );
+    }
+    if( isset( $line ) ) {
+      unset( $line );
+    }
+
     sleep(60);
+
+    // force memory cleanup for previous tagged variables (by "unset")
+    // ( php garbage collector will not free memory automatically )
+    // gc_collect_cycles() should be defined after sleep()
+    gc_collect_cycles();
+
   }
 ?>


### PR DESCRIPTION
Scalingo cron/cron example has a infinite loop.
Without a manual memory cleanup, cron will crash because all memory will be used.

![imagem](https://user-images.githubusercontent.com/5169137/62879373-e16c0000-bd22-11e9-832c-0c16026cd8d6.png)

![imagem](https://user-images.githubusercontent.com/5169137/62879722-b504b380-bd23-11e9-9627-483ab2af3076.png)

This fix introduces a cleanup of all used variables. Memory is always free. No crash. No need for a scalingo restart of clock type containers constantly.

Feel free to apply this fix and [update your php cron example](https://doc.scalingo.com/platform/app/run-scheduled-tasks).