### PR TITLE
fix(composer): install PHP Redis default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This application is a simple PHP application using the package `cron/cron` installed from Composer
 
-Application → https://sample-php-cron.scalingo.io/
+Application → https://php-cron.is-easy-on-scalingo.com
 
 ## Processes
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "require": {
         "php": "^8.1",
         "cron/cron": "^1.8.0",
-        "ext-redis": "^3.1"
+        "ext-redis": "*"
     },
     "authors": [
         {


### PR DESCRIPTION
Deployment currently fails with:

```
Root composer.json requires PHP extension ext-redis ^3.1 but it has the wrong version installed (6.1.0).
```